### PR TITLE
Initial changes to DataDogNotifier to sort out responsibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ UpgradeLog*.htm
 # Folder where NuGet package will be constructed
 nuget-package/
 /src/.nuget
+_NCrunch_*
+*.orig

--- a/Nimator.Notifiers.Integration.Tests/App.config
+++ b/Nimator.Notifiers.Integration.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+    </startup>
+</configuration>

--- a/Nimator.Notifiers.Integration.Tests/DataDogNotifierScenarios.cs
+++ b/Nimator.Notifiers.Integration.Tests/DataDogNotifierScenarios.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Nimator.Notifiers.DataDog;
+using Nimator.Settings;
+using StatsdClient;
+
+namespace Nimator.Notifiers.Integration.Tests
+{
+    internal class DataDogNotifierScenarios
+    {
+        private static DataDogNotifier _notifier;
+
+        public static void Run()
+        {
+            ConfigureNotifier();
+
+            SendOkayResultForTestCheck();
+            SendMultipleChecksInLayer();
+        }
+
+        private static void ConfigureNotifier()
+        {
+            DataDogSettings settings = new DataDogSettings()
+            {
+                Prefix = "nimatorIntegrationTests",
+                StatsdServerName = "127.0.0.1",
+                Threshold = NotificationLevel.Warning
+            };
+
+            _notifier = (DataDogNotifier)settings.ToNotifier();
+        }
+
+        private static void SendMultipleChecksInLayer()
+        {
+            NimatorResult nimatorResult = new NimatorResult(DateTime.Now);
+
+            List<ICheckResult> checks = new List<ICheckResult>();
+            checks.Add(new CheckResult("testCheck1", NotificationLevel.Okay));
+            checks.Add(new CheckResult("testCheck2", NotificationLevel.Warning));
+            checks.Add(new CheckResult("testCheck3", NotificationLevel.Error));
+            checks.Add(new CheckResult("testCheck4", NotificationLevel.Critical));
+
+            ILayerResult layerResult = new LayerResult("secondLayer", checks);
+            nimatorResult.LayerResults.Add(layerResult);
+
+            _notifier.Notify(nimatorResult);
+        }
+
+        private static void SendOkayResultForTestCheck()
+        {
+            NimatorResult nimatorResult = new NimatorResult(DateTime.Now);
+            List<ICheckResult> checks = new List<ICheckResult>();
+            checks.Add(new CheckResult("testCheck", NotificationLevel.Okay));
+            ILayerResult layerResult = new LayerResult("firstLayer", checks);
+            nimatorResult.LayerResults.Add(layerResult);
+
+            _notifier.Notify(nimatorResult);
+        }
+
+    }
+}

--- a/Nimator.Notifiers.Integration.Tests/Nimator.Notifiers.Integration.Tests.csproj
+++ b/Nimator.Notifiers.Integration.Tests/Nimator.Notifiers.Integration.Tests.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{977660D3-DFEB-429D-AAFB-8D8FEA17B221}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Nimator.Notifiers.Integration.Tests</RootNamespace>
+    <AssemblyName>Nimator.Notifiers.Integration.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="StatsdClient, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DogStatsD-CSharp-Client.3.1.0\lib\net451\StatsdClient.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DataDogNotifierScenarios.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Nimator\Nimator.csproj">
+      <Project>{65687dc2-aa7d-40fb-b5e3-252e3eaac6f4}</Project>
+      <Name>Nimator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Nimator.Notifiers.Integration.Tests/Program.cs
+++ b/Nimator.Notifiers.Integration.Tests/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nimator.Notifiers.Integration.Tests
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            DataDogNotifierScenarios.Run();
+        }
+    }
+}

--- a/Nimator.Notifiers.Integration.Tests/Properties/AssemblyInfo.cs
+++ b/Nimator.Notifiers.Integration.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Nimator.Notifiers.Integration.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Nimator.Notifiers.Integration.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("977660d3-dfeb-429d-aafb-8d8fea17b221")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Nimator.Notifiers.Integration.Tests/packages.config
+++ b/Nimator.Notifiers.Integration.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="DogStatsD-CSharp-Client" version="3.1.0" targetFramework="net451" />
+</packages>

--- a/Nimator.Tests/Notifiers/DataDog/DataDogNotifierTests.cs
+++ b/Nimator.Tests/Notifiers/DataDog/DataDogNotifierTests.cs
@@ -170,14 +170,14 @@ namespace Nimator.Notifiers.DataDog
         private DataDogNotifierTestDouble GetSut(DataDogSettings dataDogSettings)
         {
             var dataDogEventConverter = new DataDogEventConverter(dataDogSettings);
-            return new DataDogNotifierTestDouble(dataDogEventConverter);
+            return new DataDogNotifierTestDouble(dataDogEventConverter, dataDogSettings);
         }
 
         private class DataDogNotifierTestDouble : DataDogNotifier
         {
             public List<DataDogEvent> Events = new List<DataDogEvent>();
 
-            public DataDogNotifierTestDouble(IDataDogEventConverter dataDogEventConverter) : base(dataDogEventConverter)
+            public DataDogNotifierTestDouble(IDataDogEventConverter dataDogEventConverter, DataDogSettings settings) : base(dataDogEventConverter, settings)
             {
             }
 

--- a/Nimator.Tests/Notifiers/DataDog/DataDogNotifierTests.cs
+++ b/Nimator.Tests/Notifiers/DataDog/DataDogNotifierTests.cs
@@ -181,7 +181,7 @@ namespace Nimator.Notifiers.DataDog
             {
             }
 
-            protected override void NotifyDataDog(DataDogEvent dataDogEvent)
+            protected override void NotifyDataDogEvent(DataDogEvent dataDogEvent)
             {
                 Events.Add(dataDogEvent);
             }

--- a/Nimator.sln
+++ b/Nimator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2026
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nimator.ExampleConsoleApp", "Nimator.ExampleConsoleApp\Nimator.ExampleConsoleApp.csproj", "{FCDFFF7F-C1F3-4A20-9B6E-4C569C8F33BA}"
 EndProject
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Nimator\Nimator.nuspec = Nimator\Nimator.nuspec
 		readme.md = readme.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nimator.Notifiers.Integration.Tests", "Nimator.Notifiers.Integration.Tests\Nimator.Notifiers.Integration.Tests.csproj", "{977660D3-DFEB-429D-AAFB-8D8FEA17B221}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,8 +35,15 @@ Global
 		{D18E6006-295F-4BEC-A922-748313B939B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D18E6006-295F-4BEC-A922-748313B939B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D18E6006-295F-4BEC-A922-748313B939B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{977660D3-DFEB-429D-AAFB-8D8FEA17B221}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{977660D3-DFEB-429D-AAFB-8D8FEA17B221}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{977660D3-DFEB-429D-AAFB-8D8FEA17B221}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{977660D3-DFEB-429D-AAFB-8D8FEA17B221}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C426FFF6-BE56-4FBE-BEF9-4D1905E4DBCC}
 	EndGlobalSection
 EndGlobal

--- a/Nimator/Notifiers/DataDog/DataDogEventConverter.cs
+++ b/Nimator/Notifiers/DataDog/DataDogEventConverter.cs
@@ -21,10 +21,6 @@ namespace Nimator.Notifiers.DataDog
 
         public IEnumerable<DataDogEvent> Convert(INimatorResult result)
         {
-            if (result == null)  throw new ArgumentNullException(nameof(result));
-
-            if (result.Level < settings.Threshold) yield break;
-
             if (!result.LayerResults.Any())
             {
                 yield return ConvertToDataDogEvent(result.Level, 

--- a/Nimator/Notifiers/DataDog/DataDogNotifier.cs
+++ b/Nimator/Notifiers/DataDog/DataDogNotifier.cs
@@ -1,23 +1,42 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using Nimator.Settings;
 using StatsdClient;
 
 namespace Nimator.Notifiers.DataDog
 {
     class DataDogNotifier : INotifier
     {
-        private readonly IDataDogEventConverter dataDogEventConverter;
+        private readonly IDataDogEventConverter _dataDogEventConverter;
+        private readonly DataDogSettings _settings;
 
-        public DataDogNotifier(IDataDogEventConverter dataDogEventConverter)
+        public DataDogNotifier(IDataDogEventConverter dataDogEventConverter, DataDogSettings settings)
         {
-            this.dataDogEventConverter = dataDogEventConverter ?? throw new System.ArgumentNullException(nameof(dataDogEventConverter));
+            if (dataDogEventConverter == null) throw new ArgumentNullException(nameof(dataDogEventConverter));
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+
+            _dataDogEventConverter = dataDogEventConverter;
+            _settings = settings;
         }
 
         public void Notify(INimatorResult result)
         {
-            foreach(var dataDogEvent in dataDogEventConverter.Convert(result))
+            if (result == null) throw new ArgumentNullException(nameof(result));
+
+            if (result.Level >= _settings.Threshold)
             {
-                NotifyDataDogEvent(dataDogEvent);
+                foreach (var dataDogEvent in _dataDogEventConverter.Convert(result))
+                {
+                    NotifyDataDogEvent(dataDogEvent);
+                }
             }
+
+            NotifyDataDogHealthMetrics(result);
+        }
+
+        private void NotifyDataDogHealthMetrics(INimatorResult result)
+        {
+            // TODO NJ: Implementation
         }
 
         protected virtual void NotifyDataDogEvent(DataDogEvent dataDogEvent)

--- a/Nimator/Notifiers/DataDog/DataDogNotifier.cs
+++ b/Nimator/Notifiers/DataDog/DataDogNotifier.cs
@@ -16,11 +16,11 @@ namespace Nimator.Notifiers.DataDog
         {
             foreach(var dataDogEvent in dataDogEventConverter.Convert(result))
             {
-                NotifyDataDog(dataDogEvent);
+                NotifyDataDogEvent(dataDogEvent);
             }
         }
 
-        protected virtual void NotifyDataDog(DataDogEvent dataDogEvent)
+        protected virtual void NotifyDataDogEvent(DataDogEvent dataDogEvent)
         {
             DogStatsd.Increment(statName: dataDogEvent.StatName, tags: dataDogEvent.Tags);
             DogStatsd.Event(title: dataDogEvent.Title,

--- a/Nimator/Properties/AssemblyInfo.cs
+++ b/Nimator/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly:InternalsVisibleTo("Nimator.Tests")]
+[assembly: InternalsVisibleTo("Nimator.Notifiers.Integration.Tests")]
 
 [assembly: AssemblyTitle("Nimator")]
 [assembly: AssemblyDescription("Light-weight, ad-hoc library to create monitoring applications with custom checks written in c-sharp.")]

--- a/Nimator/Settings/DataDogSettings.cs
+++ b/Nimator/Settings/DataDogSettings.cs
@@ -35,7 +35,7 @@ namespace Nimator.Settings
             ConfigureStatsd();
 
             var dataDogConverter = new DataDogEventConverter(this);
-            return new DataDogNotifier(dataDogConverter);
+            return new DataDogNotifier(dataDogConverter, this);
         }
 
         /// <summary>


### PR DESCRIPTION
Move the responsibility for checking the null result and alert level into the notifier rather than the converter to allow a second metric to be sent for health monitoring purposes every time regardless of level